### PR TITLE
STEP12. 비관적락과 낙관적락 테스트

### DIFF
--- a/concert-reservation-api/src/main/java/io/hhplus/concert/domain/user/UserRepository.java
+++ b/concert-reservation-api/src/main/java/io/hhplus/concert/domain/user/UserRepository.java
@@ -12,4 +12,7 @@ public interface UserRepository {
     UserEntity changeUserInfo(UserEntity userEntity);
     void removeAllData();
 
+    Optional<UserEntity> getUserInfoForPessimisticLock(String userId);
+    Optional<UserEntity> getUserInfoForOptimisticLock(String userId);
+
 }

--- a/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/entity/user/UserEntity.java
+++ b/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/entity/user/UserEntity.java
@@ -18,6 +18,9 @@ public class UserEntity {
     @Column(nullable = false)
     private Long points;
 
+    @Version
+    private Integer version;
+
     @Builder
     public UserEntity(String userId, Long points) {
         this.userId = userId;

--- a/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/repository/user/JpaUserRepository.java
+++ b/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/repository/user/JpaUserRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,5 +15,13 @@ public interface JpaUserRepository extends JpaRepository<UserEntity, String> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT u FROM UserEntity u WHERE u.userId = :userId")
     Optional<UserEntity> findByUserIdForUpdate(String userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT u FROM UserEntity u WHERE u.userId = :userId")
+    Optional<UserEntity> findByIdWithPessimisticLock(@Param("userId") String userId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT u FROM UserEntity u WHERE u.userId = :userId")
+    Optional<UserEntity> findByIdWithOptimisticLock(@Param("userId") String userId);
 
 }

--- a/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/repository/user/UserRepositoryImpl.java
+++ b/concert-reservation-api/src/main/java/io/hhplus/concert/infrastructure/repository/user/UserRepositoryImpl.java
@@ -39,4 +39,15 @@ public class UserRepositoryImpl implements UserRepository {
     public void removeAllData() {
         jpaUserRepository.deleteAll();;
     }
+
+    @Override
+    public Optional<UserEntity> getUserInfoForPessimisticLock(String userId) {
+        return jpaUserRepository.findByIdWithPessimisticLock(userId);
+    }
+
+    @Override
+    public Optional<UserEntity> getUserInfoForOptimisticLock(String userId) {
+        return jpaUserRepository.findByIdWithOptimisticLock(userId);
+    }
+
 }

--- a/concert-reservation-api/src/test/java/io/hhplus/concert/comparison/PointRechargeServiceTest.java
+++ b/concert-reservation-api/src/test/java/io/hhplus/concert/comparison/PointRechargeServiceTest.java
@@ -1,0 +1,48 @@
+package io.hhplus.concert.comparison;
+
+import io.hhplus.concert.application.user.UserService;
+import io.hhplus.concert.domain.user.UserRepository;
+import io.hhplus.concert.infrastructure.entity.user.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class PointRechargeServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    private static final String TEST_USER_ID = "testUser";
+
+    @BeforeEach
+    public void setUp() {
+        // 사용자 존재 여부 확인 후 없으면 새로 생성
+        userRepository.getUserInfo(TEST_USER_ID).orElseGet(() -> {
+            UserEntity user = UserEntity.builder()
+                    .userId(TEST_USER_ID)
+                    .points(0L)
+                    .build();
+            return userRepository.addUser(user);
+        });
+    }
+
+    @Test
+    public void testPessimisticLockPerformance() {
+        long points = 100;
+        long timeTaken = userService.rechargePointsWithPessimisticLock(TEST_USER_ID, points);
+        System.out.println("Pessimistic Lock Time Taken: " + timeTaken + "ms");
+    }
+
+    @Test
+    public void testOptimisticLockPerformance() {
+        long points = 100;
+        long timeTaken = userService.rechargePointsWithOptimisticLock(TEST_USER_ID, points);
+        System.out.println("Optimistic Lock Time Taken: " + timeTaken + "ms");
+    }
+
+}

--- a/concert-reservation-api/src/test/resources/application.yml
+++ b/concert-reservation-api/src/test/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/concert
+    username: root
+    password: 1234
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 1000
+    database-platform: org.hibernate.dialect.MariaDBDialect


### PR DESCRIPTION
# 포인트 충전 관련 소요 시간 테스트 결과

## 테스트 결과
- **비관적 락 시간:** 5ms
- **낙관적 락 시간:** 23ms

## 분석

테스트 결과, **비관적 락이 낙관적 락보다 포인트 충전 처리 속도가 빠르게** 나타났습니다. 이는 충돌이 발생하거나 다중 트랜잭션이 동시에 접근할 때, 낙관적 락이 예상보다 더 많은 시간을 소요할 수 있음을 보여줍니다.

### 원인 분석

1. **낙관적 락의 구현 방식**  
   낙관적 락은 트랜잭션 종료 시 버전 번호를 비교하여 충돌을 확인하고, 충돌이 발생한 경우 트랜잭션을 롤백 후 재시도합니다. 이로 인해 추가적인 충돌 검사 및 재시도 비용이 발생하게 되며, 다중 사용자 접근이 많은 경우 이 과정에서 시간 소요가 증가할 수 있습니다.

2. **비관적 락의 초기 잠금 방식**  
   비관적 락은 트랜잭션 시작 시점에서부터 락을 설정하여 다른 트랜잭션의 접근을 차단합니다. 따라서 충돌 가능성이 높은 환경에서는 충돌 방지 비용을 줄여 더 빠르게 처리될 수 있습니다.

## 결론

위와 같은 분석을 바탕으로, 시간은 비관적 락이 더 빨랐지만 **포인트 충전 시 비관적 락이 낙관적 락보다 효율적일 수 있다**는 점을 확인했습니다. 특히, 다중 사용자 동시 접근이 빈번한 경우, 비관적 락의 초기 잠금 방식이 오히려 성능에 유리하게 작용할 수 있습니다.
